### PR TITLE
Add additional explanation for "Setting the max receiving rate" in streaming-programming-guide.md

### DIFF
--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -2036,7 +2036,7 @@ To run a Spark Streaming applications, you need to have the following.
   `spark.streaming.receiver.maxRate` for receivers and `spark.streaming.kafka.maxRatePerPartition`
   for Direct Kafka approach. In Spark 1.5, we have introduced a feature called *backpressure* that
   eliminate the need to set this rate limit, as Spark Streaming automatically figures out the
-  rate limits and dynamically adjusts them if the processing conditions change. This backpressure
+  rate limits and dynamically adjusts them if the processing conditions change.If the first batch of data is very large which causes the first batch is processing all the time and the task can not work normally , using a maximum rate limit can solve the problem .This backpressure
   can be enabled by setting the [configuration parameter](configuration.html#spark-streaming)
   `spark.streaming.backpressure.enabled` to `true`.
 


### PR DESCRIPTION
In streaming-programming-guide.md, as follows:

Setting the max receiving rate - If the cluster resources is not large enough for the streaming
application to process data as fast as it is being received, the receivers can be rate limited
by setting a maximum rate limit in terms of records / sec.
See the configuration parameters
spark.streaming.receiver.maxRate for receivers and spark.streaming.kafka.maxRatePerPartition
for Direct Kafka approach. In Spark 1.5, we have introduced a feature called backpressure that
eliminate the need to set this rate limit, as Spark Streaming automatically figures out the
rate limits and dynamically adjusts them if the processing conditions change. This backpressure
can be enabled by setting the configuration parameter
spark.streaming.backpressure.enabled to true.

I think we should be more rigorous. The first batch may be processing all the time and can not run normally when the first batch of data is very large for Direct Kafka approach .